### PR TITLE
Fetch contributors' details

### DIFF
--- a/core/contributors.py
+++ b/core/contributors.py
@@ -4,6 +4,9 @@ import requests
 header = {'Accept': 'application/vnd.github.v3+json', 'Authorization':config('TOKEN')}
 
 def getName(username):
+    """
+    returns name of the Github user
+    """
     url = 'https://api.github.com/users/'+username
     response = requests.get(url, headers=header)
     response_dict = response.json()
@@ -12,6 +15,9 @@ def getName(username):
     
 
 def getContributors():
+    """
+    returns contributor details
+    """
     url = 'https://api.github.com/repos/ashutoshkrris/EazyLoader/stats/contributors'
     
     response = requests.get(url, headers=header)

--- a/core/contributors.py
+++ b/core/contributors.py
@@ -1,0 +1,34 @@
+from decouple import config
+import requests
+
+header = {'Accept': 'application/vnd.github.v3+json', 'Authorization':config('TOKEN')}
+
+def getName(username):
+    url = 'https://api.github.com/users/'+username
+    response = requests.get(url, headers=header)
+    response_dict = response.json()
+
+    return response_dict["name"]
+    
+
+def getContributors():
+    url = 'https://api.github.com/repos/ashutoshkrris/EazyLoader/stats/contributors'
+    
+    response = requests.get(url, headers=header)
+    response_dict = response.json()
+
+    contributors = []
+    for contributor in response_dict:
+        username = contributor["author"]["login"]
+        name = getName(username)
+        avatar = contributor["author"]["avatar_url"]
+        profile = contributor["author"]["html_url"]
+
+        contributors.append( {
+            "username": username,
+            "name": name,
+            "avatar_url": avatar,
+            "profile_url": profile
+        })
+
+    return contributors


### PR DESCRIPTION
# Description

Adds functions to get the list of contributors' details (excluding bots) to directly serve it from the backend, using Github API.

Fixes #11 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

# Event

- [x] Hacktoberfest 2021